### PR TITLE
Make xclip exit when it loses the selection

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -415,6 +415,10 @@ doIn(Window win, const char *progname)
 	       See ICCCM section 2.2.
 	       Set dloop to sloop for forcing exit after all transfers are completed. */
 	    dloop = sloop;
+	    /* if there is no more in-progress transfer, force exit */
+	    if (!requestors) {
+	        return EXIT_SUCCESS;
+	    }
 	    continue;
 	    } else {
 	    continue;


### PR DESCRIPTION
Fix the issue #64(https://github.com/astrand/xclip/issues/64).

When receiving a SelectionClear event (i.e; lose the selection), the while loop for checking
dloop as-is ran endlessly if sloop is set to -1 (a.k.a unlimited number of requests).
This caused xclip fail to exit when it loses the selection.

Fix the problem via checking whether there is any in-progress transfer. If no, force xclip exit.